### PR TITLE
Scrollbar appears when it shouldn't due to rounding error.

### DIFF
--- a/jquery.doubleScroll.js
+++ b/jquery.doubleScroll.js
@@ -47,7 +47,7 @@
 
 		var _showScrollBar = function($self, options) {
 
-			if (options.onlyIfScroll && $self.get(0).scrollWidth <= $self.width()) {
+			if (options.onlyIfScroll && $self.get(0).scrollWidth <= Math.round($self.width())) {
 				// content doesn't scroll
 				// remove any existing occurrence...
 				$self.prev(options.topScrollBarWrapperSelector).remove();


### PR DESCRIPTION
The scrollWidth property always rounds up to an integer. 
There are some instances where $self.width() would be something like 1058.10 and $self.get(0).scrollWidth would round up to 1059, causing the condition to fail and so the scrollbar would appear when it shouldn't. 
By rounding up $self.width() we avoid this error.