### PR TITLE
Added new option to customize scrollbar show

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ The function is used to customize wrapper scrollbar and inner scrollbar as neede
 You can apply style not used globally, you can move the top scrollbar after header (example: https://jsfiddle.net/adrwxgvo/10/ ), and so on.
 
 Arguments:
-  e: resize event argument (can be undefined if it's not called from a window resize)
-  $self: the jQuery element which has the doubleScroll function applied to
-  options: the options used to create the double scroll, with all it's internally added info (topScrollBarWrapperSelector, topScrollBarInnerSelector and so on)
+- e: resize event argument (can be undefined if it's not called from a window resize)
+- $self: the jQuery element which has the doubleScroll function applied to
+- options: the options used to create the double scroll, with all it's internally added info (topScrollBarWrapperSelector, topScrollBarInnerSelector and so on)
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can configure the double scroll with the following options :
 	},
 	onlyIfScroll: true, // top scrollbar is not shown if the bottom one is not present
 	resetOnWindowResize: false, // recompute the top ScrollBar requirements when the window is resized
-	customizeAfterShowFunction: function(e, $self, options) { // this function is called every time a double scroll show happens (can be called many times, because window resize happens)
+	customizeAfterShowFunction: function(e, $self, options) { // this function is called every time a double scroll show happens (can be called many times, if window resizes happen)
 		var wrapperScrollbarElement = $(options.topScrollBarWrapperSelector); // get the element with '.doubleScroll-scroll-wrapper'
 		var innerScrollbarElement = $(options.topScrollBarInnerSelector); // get the element with '.doubleScroll-scroll'
 		// customize wrapper and inner scrollbar as needed, after the proper show

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ You can configure the double scroll with the following options :
 	onlyIfScroll: true, // top scrollbar is not shown if the bottom one is not present
 	resetOnWindowResize: false, // recompute the top ScrollBar requirements when the window is resized
 	customizeAfterShowFunction: function(e, $self, options) { // this function is called every time a double scroll show happens (can be called many times, if window resizes happen)
-		var wrapperScrollbarElement = $(options.topScrollBarWrapperSelector); // get the element with '.doubleScroll-scroll-wrapper'
-		var innerScrollbarElement = $(options.topScrollBarInnerSelector); // get the element with '.doubleScroll-scroll'
-		// customize wrapper and inner scrollbar as needed, after the proper show
+		var wrapperScrollbarElement = $(options.topScrollBarWrapperSelector); // get the element with class 'doubleScroll-scroll-wrapper' to modify it if needed
+		var innerScrollbarElement = $(options.topScrollBarInnerSelector); // get the element with class 'doubleScroll-scroll' to modify it if needed
+		
+		// The function is used to customize wrapper scrollbar and inner scrollbar as needed, after the double scrollbar show.
+		
 		// Arguments:
 		//  e: resize event argument (can be undefined if it's not called from a window resize)
 		//  $self: the jQuery element which has the doubleScroll function applied to

--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ You can configure the double scroll with the following options :
 		'overflow-y': 'hidden'
 	},
 	onlyIfScroll: true, // top scrollbar is not shown if the bottom one is not present
-	resetOnWindowResize: false // recompute the top ScrollBar requirements when the window is resized
+	resetOnWindowResize: false, // recompute the top ScrollBar requirements when the window is resized
+	customizeAfterShowFunction: function(e, $self, options) { // this function is called every time a double scroll show happens (can be called many times, because window resize happens)
+		var wrapperScrollbarElement = $(options.topScrollBarWrapperSelector); // get the element with '.doubleScroll-scroll-wrapper'
+		var innerScrollbarElement = $(options.topScrollBarInnerSelector); // get the element with '.doubleScroll-scroll'
+		// customize wrapper and inner scrollbar as needed, after the proper show
+		// Arguments:
+		//  e: resize event argument (can be undefined if it's not called from a window resize)
+		//  $self: the jQuery element which has the doubleScroll function applied to
+		//  options: the options used to create the double scroll, with all it's internally added info (topScrollBarWrapperSelector, topScrollBarInnerSelector and so on)
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,11 @@ You can configure the double scroll with the following options :
 	},
 	onlyIfScroll: true, // top scrollbar is not shown if the bottom one is not present
 	resetOnWindowResize: false, // recompute the top ScrollBar requirements when the window is resized
-	customizeAfterShowFunction: function(e, $self, options) { // this function is called every time a double scroll show happens (can be called many times, if window resizes happen)
+	customizeAfterShowFunction: function(e, $self, options) { // 
 		var wrapperScrollbarElement = $(options.topScrollBarWrapperSelector); // get the element with class 'doubleScroll-scroll-wrapper' to modify it if needed
 		var innerScrollbarElement = $(options.topScrollBarInnerSelector); // get the element with class 'doubleScroll-scroll' to modify it if needed
 		
-		// The function is used to customize wrapper scrollbar and inner scrollbar as needed, after the double scrollbar show.
-		
-		// Arguments:
-		//  e: resize event argument (can be undefined if it's not called from a window resize)
-		//  $self: the jQuery element which has the doubleScroll function applied to
-		//  options: the options used to create the double scroll, with all it's internally added info (topScrollBarWrapperSelector, topScrollBarInnerSelector and so on)
+		// Do some double scrollbar customization after the double scrollbar showing using elements $self (bottom scrollbar), wrapperScrollbarElement (element with the top scrollbar), innerScrollbarElement (inner top element width makes the scrollbar size match the bottom scrollbar size).
 	}
 }
 ```
@@ -64,6 +59,16 @@ If **true**, will display the top scrollbar only if the content is scrollable...
 
 If **true**, will attach an event to regenerate the top scrollbar when the window is resized.  
 Use it when the scrollable element has a width which is relative to the window width.
+
+###### customizeAfterShowFunction
+
+The function is used to customize wrapper scrollbar and inner scrollbar as needed, after the double scrollbar show occurs (can be called many times, if window resizes happen).
+You can apply style not used globally, you can move the top scrollbar after header (example: https://jsfiddle.net/adrwxgvo/10/ ), and so on.
+
+Arguments:
+  e: resize event argument (can be undefined if it's not called from a window resize)
+  $self: the jQuery element which has the doubleScroll function applied to
+  options: the options used to create the double scroll, with all it's internally added info (topScrollBarWrapperSelector, topScrollBarInnerSelector and so on)
 
 ## Licence
 

--- a/jquery.doubleScroll.js
+++ b/jquery.doubleScroll.js
@@ -32,7 +32,8 @@
 			},
 			onlyIfScroll: true, // top scrollbar is not shown if the bottom one is not present
 			resetOnWindowResize: false, // recompute the top ScrollBar requirements when the window is resized
-			timeToWaitForResize: 30 // wait for the last update event (usefull when browser fire resize event constantly during ressing)
+			timeToWaitForResize: 30, // wait for the last update event (usefull when browser fire resize event constantly during ressing)
+			customizeAfterShowFunction: undefined // function to customize after show
 		};
 	
 		$.extend(true, options, userOptions);
@@ -115,6 +116,10 @@
 			
 			_showScrollBar($self, options);
 			
+			// customize show function added on show handler
+			if (options.customizeAfterShowFunction && typeof options.customizeAfterShowFunction == "function")
+				options.customizeAfterShowFunction(undefined, $self, options);
+			
 			// bind the resize handler 
 			// do it once
 			if (options.resetOnWindowResize) {
@@ -122,6 +127,10 @@
 				var id;
 				var handler = function(e) {
 					_showScrollBar($self, options);
+
+					// customize show function added on show handler
+					if (options.customizeAfterShowFunction && typeof options.customizeAfterShowFunction == "function")
+						options.customizeAfterShowFunction(e, $self, options);
 				};
 			
 				$(window).bind('resize.doubleScroll', function() {


### PR DESCRIPTION
The option is needed because you might want to show scrollbars under table header (this was needed in my case). I might create a ticket too if necessary, to make it as an issue.

Simplified jsfiddle with modified jqDoubleScroll:
https://jsfiddle.net/adrwxgvo/10/

Example:
- create an empty row after table header (only one time):
```
if ($('.empty-inner-table-scroll').length === 0) {{ // only add empty row only once
$('#[Table Header Id]').after('<tr><td class="empty-inner-table-scroll" colspan="42"></td></tr>'); // colspan is better calculated properly, if possible; if not, any number greater than actual number of columns might work (with performance issues sometimes)
```
- customize showing the scrollbar in order to show under table header:
```
customizeAfterShowFunction: function(e, self, options) {
    var wrapperScrollbarElement = $(options.topScrollBarWrapperSelector); // '.doubleScroll-scroll-wrapper'
    var emptyRowElement = $('.empty-inner-table-scroll');
    
    if (wrapperScrollbarElement.length !== 0) {
        // make empty row the size of the scrollbar wrapper (because the scrollbar will be on top of the empty row later)
        emptyRowElement.height(wrapperScrollbarElement.height());
        
        // move wrapper scrollbar element on top of empty row (under header)
        wrapperScrollbarElement.css('position', 'absolute !important'); // needed to be able to move the element
        var tableElement = $('table#[Table Id]'); // optional, if scrollbar is needed exactly on the table border, positioned exactly like the bottom scrollbar (with no offset difference between them on x axis)
        var offset = emptyRowElement.offset();
        offset.left = offset.left
            - parseInt(tableElement.css('border-left-width'), 10)
            - parseInt(tableElement.css('margin-left'), 10)
            - parseInt(tableElement.css('padding-left'), 10);
        wrapperScrollbarElement.offset(offset);

        // scrollbar on top of readonly divs with z-index 1000 (in my case) to be able to scroll readonly grids too (with both scrollbars)
        wrapperScrollbarElement.css('z-index', '1001');
    
        // refresh inner scrollbar element width to make scrolls size equal (this is needed in other places too, in case the table size changes)
        var innerScrollbarElement = $(options.topScrollBarInnerSelector); // '.doubleScroll-scroll'
        if (innerScrollbarElement.lenght !== 0 && tableElement.length !== 0)
            innerScrollbarElement.width(tableElement.outerWidth());
    } else {
        // if the wrapper element doesn't exist, the empty row must be hidden (height zero works too)
        emptyRowElement.height(0);
    }
}
```